### PR TITLE
same as commit d490a05 but with NMI vector @ FEC1

### DIFF
--- a/kickstart.a65
+++ b/kickstart.a65
@@ -353,7 +353,7 @@ reset_machine_state:
 		; would run off somewhere odd instead of resetting properly. Now it
 		; will auto-reset after 65535 cycles if the watchdog is not cleared).
 		lda #$2a
-		sta $d67d
+		sta hypervisor_feature_enables
 
 		jsr resetdisplay
 		jsr erasescreen
@@ -1775,6 +1775,7 @@ g61:		sta $0800,x
 
 		jsr task_set_c64_memorymap
 		jsr task_set_pc_to_reset_vector
+		jsr task_dummy_nmi_vector
 
 		; Exit hypervisor and transfer control to ROM
 		sta hypervisor_enterexit_trigger

--- a/kickstart_task.a65
+++ b/kickstart_task.a65
@@ -58,6 +58,16 @@ task_set_pc_to_reset_vector:
 	sta hypervisor_pch
 	rts
 
+; Set dummy C64 NMI vector
+; This avoid a nasty crash if NMI is called during kickstart
+; Points to a RTI instruction in $FEC1
+task_dummy_nmi_vector:
+	lda #<$FEC1
+	sta $0318
+	lda #>$FEC1
+	sta $0319
+	rts
+
 ; Set all page entries and current page number to all zeroes
 ; so that we don't think any page is loaded.
 ; XXX - Is all zeroes the best value here?  Physical page 0 is $00000000, which


### PR DESCRIPTION
Same as commit d490a05 but with NMI vector at address $FEC1.
Revert commit 32310e8, caused boot-up crash when tested on HW.
